### PR TITLE
Factor out UI code

### DIFF
--- a/DirectXTutorial/DirectXTutorial.vcxproj
+++ b/DirectXTutorial/DirectXTutorial.vcxproj
@@ -140,6 +140,7 @@
   <ItemGroup>
     <ClCompile Include="Entity.cpp" />
     <ClCompile Include="imgui.cpp" />
+    <ClCompile Include="ImGuiInterface.cpp" />
     <ClCompile Include="imgui_draw.cpp" />
     <ClCompile Include="imgui_impl_dx11.cpp" />
     <ClCompile Include="imgui_impl_win32.cpp" />
@@ -165,12 +166,14 @@
     <ClInclude Include="Entity.h" />
     <ClInclude Include="imconfig.h" />
     <ClInclude Include="imgui.h" />
+    <ClInclude Include="ImGuiInterface.h" />
     <ClInclude Include="imgui_impl_dx11.h" />
     <ClInclude Include="imgui_impl_win32.h" />
     <ClInclude Include="imgui_internal.h" />
     <ClInclude Include="imstb_rectpack.h" />
     <ClInclude Include="imstb_textedit.h" />
     <ClInclude Include="imstb_truetype.h" />
+    <ClInclude Include="Interface.h" />
     <ClInclude Include="PerspectiveMaterial.h" />
     <ClInclude Include="Utils.h" />
     <ClInclude Include="Loaders.h" />

--- a/DirectXTutorial/DirectXTutorial.vcxproj.filters
+++ b/DirectXTutorial/DirectXTutorial.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="Entity.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ImGuiInterface.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Material.h">
@@ -96,6 +99,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Entity.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Interface.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ImGuiInterface.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/DirectXTutorial/ImGuiInterface.cpp
+++ b/DirectXTutorial/ImGuiInterface.cpp
@@ -10,59 +10,56 @@ namespace UI
 
 void CameraControls::Render()
 {
-		ImGui::Begin("Camera Controls");
-		ImGui::SliderFloat("FOV", &fov, 0.1f, M_PI);
-		ImGui::SliderFloat("Aspect Ratio", &aspectRatio, -30.0f, 30.0f);
-		ImGui::SliderFloat("Near Z", &nearZ, 0, 10.0f);
-		ImGui::SliderFloat("Far Z", &farZ, 0, 100.0f);
-		ImGui::End();
+	ImGui::Begin("Camera Controls");
+	ImGui::SliderFloat("FOV", &fov, 0.1f, M_PI);
+	ImGui::SliderFloat("Aspect Ratio", &aspectRatio, -30.0f, 30.0f);
+	ImGui::SliderFloat("Near Z", &nearZ, 0, 10.0f);
+	ImGui::SliderFloat("Far Z", &farZ, 0, 100.0f);
+	ImGui::End();
 }
 
 void ObjectControls::Render()
 {
 
-		ImGui::Begin("Object Controls");
+	ImGui::Begin("Object Controls");
 
-		ImGui::Text("Position");
-		ImGui::SliderFloat("X", &x, -30.0f, 30.0f);
-		ImGui::SliderFloat("Y", &y, -30.0f, 30.0f);
-		ImGui::SliderFloat("Z", &z, -30.0f, 30.0f);
+	ImGui::Text("Position");
+	ImGui::SliderFloat("X", &x, -30.0f, 30.0f);
+	ImGui::SliderFloat("Y", &y, -30.0f, 30.0f);
+	ImGui::SliderFloat("Z", &z, -30.0f, 30.0f);
 
-		ImGui::Text("Rotation");
-		ImGui::SliderFloat("Rotation X", &rotx, 0.0f, M_PI * 2.0f);
-		ImGui::SliderFloat("Rotation Y", &roty, 0.0f, M_PI * 2.0f);
-		ImGui::SliderFloat("Rotation Z", &rotz, 0.0f, M_PI * 2.0f);
+	ImGui::Text("Rotation");
+	ImGui::SliderFloat("Rotation X", &rotx, 0.0f, M_PI * 2.0f);
+	ImGui::SliderFloat("Rotation Y", &roty, 0.0f, M_PI * 2.0f);
+	ImGui::SliderFloat("Rotation Z", &rotz, 0.0f, M_PI * 2.0f);
 
-		ImGui::Text("Clear Colour");
-		ImGui::ColorEdit3("clear color", (float*)&backgroundColor);
+	ImGui::Text("Clear Colour");
+	ImGui::ColorEdit3("clear color", (float*)&backgroundColor);
 
-		ImGui::Text("%.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
-		ImGui::End();
+	ImGui::Text("%.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+	ImGui::End();
 }
 
 void ImGuiInterface::Init(HWND hWnd, ID3D11Device* dev, ID3D11DeviceContext* devCon)
 {
 	// Setup Dear ImGui context
-    IMGUI_CHECKVERSION();
-    ImGui::CreateContext();
-    ImGuiIO& io = ImGui::GetIO(); (void)io;
-    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
-    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
+	IMGUI_CHECKVERSION();
+	ImGui::CreateContext();
+	ImGuiIO& io = ImGui::GetIO(); (void)io;
 
-    // Setup Dear ImGui style
-    ImGui::StyleColorsDark();
-    //ImGui::StyleColorsClassic();
+	// Setup Dear ImGui style
+	ImGui::StyleColorsDark();
 
-    // Setup Platform/Renderer bindings
-    ImGui_ImplWin32_Init(hWnd);
-    ImGui_ImplDX11_Init(dev, devCon);
+	// Setup Platform/Renderer bindings
+	ImGui_ImplWin32_Init(hWnd);
+	ImGui_ImplDX11_Init(dev, devCon);
 }
 
 ImGuiInterface::~ImGuiInterface()
 {
-	 ImGui_ImplDX11_Shutdown();
-    ImGui_ImplWin32_Shutdown();
-    ImGui::DestroyContext();
+	ImGui_ImplDX11_Shutdown();
+	ImGui_ImplWin32_Shutdown();
+	ImGui::DestroyContext();
 }
 
 void ImGuiInterface::Render()
@@ -81,12 +78,12 @@ void ImGuiInterface::Render()
 
 CameraControls& ImGuiInterface::CameraState()
 {
-	 return m_CameraControls;
+	return m_CameraControls;
 }
 
 ObjectControls& ImGuiInterface::ObjectState()
 {
-	 return m_ObjectControls;
+	return m_ObjectControls;
 }
 
 } // namespace UI

--- a/DirectXTutorial/ImGuiInterface.cpp
+++ b/DirectXTutorial/ImGuiInterface.cpp
@@ -1,0 +1,93 @@
+#include "ImGuiInterface.h"
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+
+namespace Engine
+{
+namespace UI 
+{
+
+void CameraControls::Render()
+{
+		ImGui::Begin("Camera Controls");
+		ImGui::SliderFloat("FOV", &fov, 0.1f, M_PI);
+		ImGui::SliderFloat("Aspect Ratio", &aspectRatio, -30.0f, 30.0f);
+		ImGui::SliderFloat("Near Z", &nearZ, 0, 10.0f);
+		ImGui::SliderFloat("Far Z", &farZ, 0, 100.0f);
+		ImGui::End();
+}
+
+void ObjectControls::Render()
+{
+
+		ImGui::Begin("Object Controls");
+
+		ImGui::Text("Position");
+		ImGui::SliderFloat("X", &x, -30.0f, 30.0f);
+		ImGui::SliderFloat("Y", &y, -30.0f, 30.0f);
+		ImGui::SliderFloat("Z", &z, -30.0f, 30.0f);
+
+		ImGui::Text("Rotation");
+		ImGui::SliderFloat("Rotation X", &rotx, 0.0f, M_PI * 2.0f);
+		ImGui::SliderFloat("Rotation Y", &roty, 0.0f, M_PI * 2.0f);
+		ImGui::SliderFloat("Rotation Z", &rotz, 0.0f, M_PI * 2.0f);
+
+		ImGui::Text("Clear Colour");
+		ImGui::ColorEdit3("clear color", (float*)&backgroundColor);
+
+		ImGui::Text("%.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+		ImGui::End();
+}
+
+void ImGuiInterface::Init(HWND hWnd, ID3D11Device* dev, ID3D11DeviceContext* devCon)
+{
+	// Setup Dear ImGui context
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO(); (void)io;
+    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
+    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
+
+    // Setup Dear ImGui style
+    ImGui::StyleColorsDark();
+    //ImGui::StyleColorsClassic();
+
+    // Setup Platform/Renderer bindings
+    ImGui_ImplWin32_Init(hWnd);
+    ImGui_ImplDX11_Init(dev, devCon);
+}
+
+ImGuiInterface::~ImGuiInterface()
+{
+	 ImGui_ImplDX11_Shutdown();
+    ImGui_ImplWin32_Shutdown();
+    ImGui::DestroyContext();
+}
+
+void ImGuiInterface::Render()
+{
+	// Start the Dear ImGui frame
+	ImGui_ImplDX11_NewFrame();
+	ImGui_ImplWin32_NewFrame();
+	ImGui::NewFrame();
+
+	m_CameraControls.Render();
+	m_ObjectControls.Render();
+
+	ImGui::Render();
+	ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+}
+
+CameraControls& ImGuiInterface::CameraState()
+{
+	 return m_CameraControls;
+}
+
+ObjectControls& ImGuiInterface::ObjectState()
+{
+	 return m_ObjectControls;
+}
+
+} // namespace UI
+} // namespace Engine

--- a/DirectXTutorial/ImGuiInterface.h
+++ b/DirectXTutorial/ImGuiInterface.h
@@ -15,44 +15,44 @@ namespace UI
 
 struct ObjectControls : Controls
 {
-	 float x;
-	 float y;
-	 float z;
+	float x;
+	float y;
+	float z;
 
-	 float rotx;
-	 float roty;
-	 float rotz;
+	float rotx;
+	float roty;
+	float rotz;
 
-	 // Default cornflower blue :)
-	 float backgroundColor[4] = { 0.0f, 0.2f, 0.4f, 1.0f };
+	// Default cornflower blue :)
+	float backgroundColor[4] = { 0.0f, 0.2f, 0.4f, 1.0f };
 
-	 void Render() override;
+	void Render() override;
 };
 
 struct CameraControls : Controls
 {
-	 float fov;
-	 float aspectRatio;
-	 float nearZ;
-	 float farZ;
+	float fov;
+	float aspectRatio;
+	float nearZ;
+	float farZ;
 
-	 void Render() override;
+	void Render() override;
 };
 
 class ImGuiInterface : Interface
 {
 public:
-	 void Init(HWND hWnd, ID3D11Device* dev, ID3D11DeviceContext* devCon);
-	 ~ImGuiInterface();
+	void Init(HWND hWnd, ID3D11Device* dev, ID3D11DeviceContext* devCon);
+	~ImGuiInterface();
 
-	 void Render() override;
+	void Render() override;
 
-	 ObjectControls& ObjectState();
-	 CameraControls& CameraState();
+	ObjectControls& ObjectState();
+	CameraControls& CameraState();
 
 private:
-	 ObjectControls m_ObjectControls;
-	 CameraControls m_CameraControls;
+	ObjectControls m_ObjectControls;
+	CameraControls m_CameraControls;
 };
 
 } // namespace UI

--- a/DirectXTutorial/ImGuiInterface.h
+++ b/DirectXTutorial/ImGuiInterface.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <d3d11.h>
+#include "imgui.h"
+#include "imgui_impl_win32.h"
+#include "imgui_impl_dx11.h"
+#include <windows.h>
+
+#include "Interface.h"
+
+namespace Engine
+{
+namespace UI 
+{
+
+struct ObjectControls : Controls
+{
+	 float x;
+	 float y;
+	 float z;
+
+	 float rotx;
+	 float roty;
+	 float rotz;
+
+	 // Default cornflower blue :)
+	 float backgroundColor[4] = { 0.0f, 0.2f, 0.4f, 1.0f };
+
+	 void Render() override;
+};
+
+struct CameraControls : Controls
+{
+	 float fov;
+	 float aspectRatio;
+	 float nearZ;
+	 float farZ;
+
+	 void Render() override;
+};
+
+class ImGuiInterface : Interface
+{
+public:
+	 void Init(HWND hWnd, ID3D11Device* dev, ID3D11DeviceContext* devCon);
+	 ~ImGuiInterface();
+
+	 void Render() override;
+
+	 ObjectControls& ObjectState();
+	 CameraControls& CameraState();
+
+private:
+	 ObjectControls m_ObjectControls;
+	 CameraControls m_CameraControls;
+};
+
+} // namespace UI
+} // namespace Engine

--- a/DirectXTutorial/Interface.h
+++ b/DirectXTutorial/Interface.h
@@ -7,12 +7,12 @@ namespace UI
 
 class Controls
 {
-	 virtual void Render() = 0;
+	virtual void Render() = 0;
 };
 
 class Interface
 {
-	 virtual void Render() = 0;
+	virtual void Render() = 0;
 };
 
 } // namespace UI

--- a/DirectXTutorial/Interface.h
+++ b/DirectXTutorial/Interface.h
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace Engine
+{
+namespace UI 
+{
+
+class Controls
+{
+	 virtual void Render() = 0;
+};
+
+class Interface
+{
+	 virtual void Render() = 0;
+};
+
+} // namespace UI
+} // namespace Engine

--- a/DirectXTutorial/main.cpp
+++ b/DirectXTutorial/main.cpp
@@ -11,10 +11,6 @@
 #include <DirectXMath.h>
 #include <d3dcompiler.h>
 
-#include "imgui.h"
-#include "imgui_impl_win32.h"
-#include "imgui_impl_dx11.h"
-
 #include "Entity.h"
 #include "ImGuiInterface.h"
 #include "Loaders.h"
@@ -147,24 +143,6 @@ LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPara
 	}
 
 	return DefWindowProc(hWnd, message, wParam, lParam);
-}
-
-void InitDearImGUI(HWND hWnd)
-{
-	// Setup Dear ImGui context
-    IMGUI_CHECKVERSION();
-    ImGui::CreateContext();
-    ImGuiIO& io = ImGui::GetIO(); (void)io;
-    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
-    //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
-
-    // Setup Dear ImGui style
-    ImGui::StyleColorsDark();
-    //ImGui::StyleColorsClassic();
-
-    // Setup Platform/Renderer bindings
-    ImGui_ImplWin32_Init(hWnd);
-    ImGui_ImplDX11_Init(dev, devCon);
 }
 
 void InitUI(HWND hWnd)

--- a/DirectXTutorial/main.cpp
+++ b/DirectXTutorial/main.cpp
@@ -332,21 +332,21 @@ void RenderFrame(void)
 
 	Engine::PerspectiveConstantBuffer cBuffer;
 	cBuffer.worldTransform = DirectX::XMMatrixRotationRollPitchYaw(
-		 objectControlsState.rotx, 
-		 objectControlsState.roty, 
-		 objectControlsState.rotz);
+		objectControlsState.rotx, 
+		objectControlsState.roty, 
+		objectControlsState.rotz);
 	cBuffer.worldTransform *= DirectX::XMMatrixScaling(0.5f, 0.5f, 0.5f);
 	cBuffer.worldTransform *= DirectX::XMMatrixTranslation(
-		 objectControlsState.x,
-		 objectControlsState.y,
-		 objectControlsState.z);
+		objectControlsState.x,
+		objectControlsState.y,
+		objectControlsState.z);
 	//cBuffer.cameraTransform = DirectX::XMMatrixPerspectiveLH(2.0f, 1.0f, 0.1f, 50.0f);
 	cBuffer.cameraTransform = DirectX::XMMatrixPerspectiveFovLH(
-		 cameraControlsState.fov, 
-		 cameraControlsState.aspectRatio, 
-		 cameraControlsState.nearZ, 
-		 cameraControlsState.farZ);
-		perspectiveMaterial.UpdateConstantBuffer(devCon, cBuffer);
+		cameraControlsState.fov, 
+		cameraControlsState.aspectRatio, 
+		cameraControlsState.nearZ, 
+		cameraControlsState.farZ);
+	perspectiveMaterial.UpdateConstantBuffer(devCon, cBuffer);
 
 	// Clear render targets
 	devCon->ClearRenderTargetView(backbuffer, objectControlsState.backgroundColor);


### PR DESCRIPTION
- Creates Interface and Controls interfaces
    - `Controls` represents a group of user interactive controls and must implement a render function
    - `Interface` is expected to have some renderable `Controls` and is in charge of rendering them
- Created an `ImGui` implementation of `Interface` which takes care of all `DearImGui` usage
    - Contains 2 `Controls` groups
        - `ObjectControls` contains controls affecting the (currently only) object in the scene
        - `CameraControls` contains controls affecting the camera (which still isn't an actual object)
- Now `RenderFrame` only needs to call `ImGuiInterface::Render`! 
    - And optionally grab the current state of the controls to update the scene!  